### PR TITLE
Add config for linux aarch64 build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
Hi,

I have added the config including the linker for cross compiling.

Be sure to install the cross compiler, for example, by
```
# arm
sudo apt install gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi g++-arm-linux-gnueabi
# arm64
sudo apt install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu g++-aarch64-linux-gnu
```

Then you can build with
```
cargo build --release --target=aarch64-unknown-linux-gnu
```