### PR TITLE
Setup CD tool for MacOS M1 build

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -6,7 +6,7 @@ workflows:
         script: git submodule update --init --recursive
       - name: Install rust non-interactively
         script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      -name: Setup rust environment
+      - name: Setup rust environment
         script: source $HOME/.cargo/env
       - name: Use nightly rust
         script: rustup default nightly

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,5 +1,5 @@
 workflows:
-  ios-build:
+  aarch64-darwin-build:
     environment:
       xcode: 13.3
     scripts:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,12 +1,13 @@
 workflows:
-  aarch64-darwin-build:
+  aarch64-darwin-build
+    instance_type: mac_mini_m1
     environment:
       xcode: 13.3
     scripts:
       - name: Update submodule
         script: git submodule update --init --recursive
-      - name: Install rust
-        script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+      - name: Install rust non-interactively
+        script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Use nightly rust
         script: rustup default nightly
       - name: Build

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -7,6 +7,8 @@ workflows:
         script: git submodule update --init --recursive
       - name: Install rust non-interactively
         script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      -name: Setup rust environment
+        script: source $HOME/.cargo/env
       - name: Use nightly rust
         script: rustup default nightly
       - name: Build

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,6 +1,5 @@
 workflows:
   aarch64-darwin-build:
-    instance-type: mac_mini_m1
     scripts:
       - name: Update submodule
         script: git submodule update --init --recursive

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -5,12 +5,10 @@ workflows:
         script: git submodule update --init --recursive
       - name: Install rust non-interactively
         script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      - name: Setup rust environment
-        script: source $HOME/.cargo/env
       - name: Use nightly rust
-        script: rustup default nightly
+        script: $HOME/.cargo/bin/rustup default nightly
       - name: Build
-        script: cargo build --release
+        script: $HOME/.cargo/bin/cargo build --release
 
     artifacts:
       - target/release/mltd

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,7 +1,6 @@
 workflows:
-  aarch64-darwin-build
-    environment:
-      xcode: 13.3
+  aarch64-darwin-build:
+    instance-type: mac_mini_m1
     scripts:
       - name: Update submodule
         script: git submodule update --init --recursive

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,6 +1,5 @@
 workflows:
   aarch64-darwin-build
-    instance_type: mac_mini_m1
     environment:
       xcode: 13.3
     scripts:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,0 +1,16 @@
+workflows:
+  ios-build:
+    environment:
+      xcode: 13.3
+    scripts:
+      - name: Update submodule
+        script: git submodule update --init --recursive
+      - name: Install rust
+        script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+      - name: Use nightly rust
+        script: rustup default nightly
+      - name: Build
+        script: cargo build --release
+
+    artifacts:
+      - target/release/mltd


### PR DESCRIPTION
Hi,

I have setup the continuous delivery (CD) platform with its config so that you can build M1 executable without a real M1 device.

Please check https://codemagic.io/start/.
