### PR TITLE
Update libcgss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "acb"
-version = "0.1.0"
+version = "2.0.1"
 dependencies = [
  "cmake",
  "cxx",
@@ -72,9 +72,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.14"
+version = "4.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
+checksum = "c12ed66a79a555082f595f7eb980d08669de95009dd4b3d61168c573ebe38fc9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.14"
+version = "4.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
+checksum = "0f4645eab3431e5a8403a96bea02506a8b35d28cd0f0330977dd5d22f9c84f43"
 dependencies = [
  "anstyle",
  "clap_lex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = "1.0.195"
 [workspace.dependencies.clap]
 default-features = false
 features = ["std", "help", "usage"]
-version = "4.4.14"
+version = "4.4.15"
 
 [workspace.dependencies.env_logger]
 default-features = false

--- a/acb/Cargo.toml
+++ b/acb/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-authors.workspace = true
+authors = { workspace = true }
 build = "build.rs"
 description = "Rust bindings for libcgss"
-edition.workspace = true
+edition = { workspace = true }
 name = "acb"
-license.workspace = true
-repository.workspace = true
-version = "0.1.0"
+license = { workspace = true }
+repository = { workspace = true }
+version = "2.0.1"
 
 [dependencies]
 cxx = "1.0.115"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-authors.workspace = true
+authors = { workspace = true }
 categories = ["command-line-utilities"]
 description = "A CLI made for assets in THE iDOLM@STER® MILLION LIVE! THEATER DAYS (MLTD)"
-edition.workspace = true
+edition = { workspace = true }
 homepage = "https://github.com/nicks96432/mltd-asset-downloader"
 keywords = ["downloader", "MLTD", "mirishita", "theaterdays", "unpack"]
-license.workspace = true
+license = { workspace = true }
 name = "mltd"
 readme = "README.md"
-repository.workspace = true
+repository = { workspace = true }
 version = "2.0.0"
 
 [dependencies]

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-authors.workspace = true
+authors = { workspace = true }
 description = "Download assets from MLTD asset server"
-edition.workspace = true
-license.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
 name = "mltd-asset-download"
-repository.workspace = true
+repository = { workspace = true }
 version = "0.1.0"
 
 [dependencies]

--- a/extract/Cargo.toml
+++ b/extract/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-authors.workspace = true
+authors = { workspace = true }
 description = "Extract media from MLTD assets"
-edition.workspace = true
-license.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
 name = "mltd-asset-extract"
-repository.workspace = true
+repository = { workspace = true }
 version = "0.1.0"
 
 [dependencies]

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-authors.workspace = true
+authors = { workspace = true }
 description = "Download asset manifest from MLTD asset server"
-edition.workspace = true
-license.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
 name = "mltd-asset-manifest"
-repository.workspace = true
+repository = { workspace = true }
 version = "0.1.0"
 
 [dependencies]


### PR DESCRIPTION
This PR fixes an potential undefined behavior, see [here](https://github.com/nicks96432/libcgss/commit/9bb87b9b6d1a0bfb9fb67addec4de78489bc14fb) for more details.
This PR also bumps `acb` crate to `2.0.1`.